### PR TITLE
Build fixes for MSVC 12 (a.k.a. MSVS 2013) compiler.

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -1071,19 +1071,6 @@ class parser
         date.tm_sec = sec;
 #endif
 
-        // correctly fill in missing values
-        // "portable" version of timegm()
-        char* tz = getenv("TZ");
-        setenv("TZ", "", 1);
-        tzset();
-        time_t t = mktime(&date);
-        date = *gmtime(&t);
-        if (tz)
-            setenv("TZ", tz, 1);
-        else
-            unsetenv("TZ");
-        tzset();
-
         return std::make_shared<toml_value<std::tm>>(date);
     }
 


### PR DESCRIPTION
Most of those are self-explanatory, except for the last one. It took me quite some time to convince myself that this code really wasn't needed, but it definitely seems so, finally. Hopefully the commit message explains why.
