### PR TITLE
Avoid clang warnings in cpptoml sources.

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -662,11 +662,7 @@ class parser
     }
 
   private:
-#if defined __has_feature
-    #if __has_feature(attribute_analyzer_noreturn)
-    __attribute__((analyzer_noreturn))
-    #endif
-#elif defined _MSC_VER
+#if defined _MSC_VER
     __declspec(noreturn)
 #elif defined __GNUC__
     __attribute__((noreturn))


### PR DESCRIPTION
Use noreturn attribute for clang as well, otherwise every use of
throw_parse_exception() results in a -Wno-return warning.

The analyzer_noreturn attribute was inappropriate here as it indicates that
the function can, actually, return, but should just be considered as not
returning for static analysis purposes, which was not the case here. And it
doesn't help with compilation warnings at all, so all it did was to prevent
the noreturn attribute from being used.
