### PR TITLE
added biicode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.o
 .ycm_*
 build/
+bii/
+bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ compiler:
   - gcc
 
 install:
-  - sudo apt-get -y install lib32z1
+  - sudo apt-get update -qq
+  - sudo apt-get install -y  lib32z1   
   - wget http://www.cmake.org/files/v3.0/cmake-3.0.1-Linux-i386.sh
   - sudo sh cmake-3.0.1-Linux-i386.sh --prefix=/usr/local --exclude-subdir
   # credit: https://github.com/beark/ftl/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
   - gcc
 
 install:
-  - sudo apt-get install libc6-i386
+  - sudo apt-get -y install lib32z1
   - wget http://www.cmake.org/files/v3.0/cmake-3.0.1-Linux-i386.sh
   - sudo sh cmake-3.0.1-Linux-i386.sh --prefix=/usr/local --exclude-subdir
   # credit: https://github.com/beark/ftl/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(CheckCXXSourceRuns)
 
 option(USE_LIBCXX "Use libc++ for the C++ standard library" ON)
 
-if(UNIX)
+if(UNIX OR MINGW)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         if(USE_LIBCXX)
@@ -108,6 +108,20 @@ int main() {
     date.tm_sec = stoi(results[6]);
     return 0;
 }" CPPTOML_HAS_STD_REGEX)
+
+IF(BIICODE)
+    ADD_BIICODE_TARGETS()
+    # These lines can be factorized, but dont want to mess at first instance
+    target_compile_options(${BII_LIB_TARGET} INTERFACE ${STDOPT} ${LIBCXX_OPTIONS})
+    if(CPPTOML_HAS_STD_PUT_TIME)
+        target_compile_definitions(${BII_LIB_TARGET} INTERFACE -DCPPTOML_HAS_STD_PUT_TIME=1)
+    endif()
+    if (CPPTOML_HAS_STD_REGEX)
+        target_compile_definitions(${BII_LIB_TARGET} INTERFACE -DCPPTOML_HAS_STD_REGEX=1)
+    endif()
+    target_link_libraries(${BII_LIB_TARGET} INTERFACE ${LIBCXX_LIBRARY} ${CXXABI_LIBRARY})
+    return()
+ENDIF()
 
 add_library(cpptoml INTERFACE)
 target_include_directories(cpptoml INTERFACE ${PROJECT_SOURCE_DIR}/include)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ make
 ```
 
 Compile it on Linux, OS X and Windows (MinGW 4.9 y Visual Studio 12) with biicode:
+
 ```
 bii init -L
 bii build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A header-only library for parsing [TOML][toml] configuration files.
 
 Targets: [TOML v0.4.0][currver]
+[![Build Status](https://webapi.biicode.com/v1/badges/amalulla/amalulla/cpptoml/master)](https://www.biicode.com/amalulla/cpptoml) 
 
 It is reasonably conforming, with the exception of unicode escape
 characters in strings. This includes support for the new DateTime format,
@@ -49,6 +50,12 @@ mkdir build
 cd build
 cmake ../
 make
+```
+
+Compile it on Linux, OS X and Windows (MinGW 4.9 y Visual Studio 12) with biicode:
+```
+bii init -L
+bii build
 ```
 
 # Example Usage

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,0 +1,4 @@
+# Biicode configuration file
+
+[paths]
+    include


### PR DESCRIPTION
Hi skystrife,

I just added [biicode](https://www.biicode.com/) support for your library and explained basics in the readme , it's a biicode.conf file and some unobtrusive changes in CMakeLists.txt

To try it out with biicode (once installed):

```
 $ git clone https://github.com/MariadeAnton/cpptoml
 $ cd cpptoml
 $ bii init -L
 $ bii build
```
I've published **cpptoml** in biicode [amalulla/cpptoml](https://www.biicode.com/amalulla/cpptoml), but would be great if you could register keep it up-to-date in biicode. 

Hope you like this,

Maria

