### PR TITLE
Added functions to allow building of arrays and table_arrays in code.

### DIFF
--- a/build_toml.cpp
+++ b/build_toml.cpp
@@ -1,0 +1,69 @@
+#include <cpptoml.h>
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+    cpptoml::table root;
+    root.insert("Integer", 1234L);
+    root.insert("Double", 1.234);
+    root.insert("String", std::string("ABCD"));
+    
+    auto table = std::make_shared<cpptoml::table>();
+    table->insert("ElementOne", 1L);
+    table->insert("ElementTwo", 2.0);
+    table->insert("ElementThree", std::string("THREE"));
+    
+    auto nested_table = std::make_shared<cpptoml::table>();
+    nested_table->insert("ElementOne", 2L);
+    nested_table->insert("ElementTwo", 3.0);
+    nested_table->insert("ElementThree", std::string("FOUR"));
+    
+    table->insert("Nested", nested_table);
+    
+    
+    root.insert("Table", table);
+    
+    auto int_array = std::make_shared<cpptoml::array>();
+    int_array->push_back(1L);
+    int_array->push_back(2L);
+    int_array->push_back(3L);
+    int_array->push_back(4L);
+    int_array->push_back(5L);
+    
+    root.insert("IntegerArray", int_array);
+    
+    auto double_array = std::make_shared<cpptoml::array>();
+    double_array->push_back(1.1);
+    double_array->push_back(2.2);
+    double_array->push_back(3.3);
+    double_array->push_back(4.4);
+    double_array->push_back(5.5);
+    
+    root.insert("DoubleArray", double_array);
+    
+    auto string_array = std::make_shared<cpptoml::array>();
+    string_array->push_back(std::string("A"));
+    string_array->push_back(std::string("B"));
+    string_array->push_back(std::string("C"));
+    string_array->push_back(std::string("D"));
+    string_array->push_back(std::string("E"));
+    
+    root.insert("StringArray", string_array);
+    
+    auto table_array = std::make_shared<cpptoml::table_array>();
+    table_array->push_back(table);
+    table_array->push_back(table);
+    table_array->push_back(table);
+    
+    root.insert("TableArray", table_array);
+    
+    auto array_of_arrays = std::make_shared<cpptoml::array>();
+    array_of_arrays->push_back(int_array);
+    array_of_arrays->push_back(double_array);
+    array_of_arrays->push_back(string_array);
+    
+    root.insert("ArrayOfArrays", array_of_arrays);
+    
+    std::cout << root;
+    return 0;
+}

--- a/build_toml.cpp
+++ b/build_toml.cpp
@@ -1,69 +1,68 @@
 #include <cpptoml.h>
 #include <iostream>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     cpptoml::table root;
     root.insert("Integer", 1234L);
     root.insert("Double", 1.234);
     root.insert("String", std::string("ABCD"));
-    
+
     auto table = std::make_shared<cpptoml::table>();
     table->insert("ElementOne", 1L);
     table->insert("ElementTwo", 2.0);
     table->insert("ElementThree", std::string("THREE"));
-    
+
     auto nested_table = std::make_shared<cpptoml::table>();
     nested_table->insert("ElementOne", 2L);
     nested_table->insert("ElementTwo", 3.0);
     nested_table->insert("ElementThree", std::string("FOUR"));
-    
+
     table->insert("Nested", nested_table);
-    
-    
+
     root.insert("Table", table);
-    
+
     auto int_array = std::make_shared<cpptoml::array>();
     int_array->push_back(1L);
     int_array->push_back(2L);
     int_array->push_back(3L);
     int_array->push_back(4L);
     int_array->push_back(5L);
-    
+
     root.insert("IntegerArray", int_array);
-    
+
     auto double_array = std::make_shared<cpptoml::array>();
     double_array->push_back(1.1);
     double_array->push_back(2.2);
     double_array->push_back(3.3);
     double_array->push_back(4.4);
     double_array->push_back(5.5);
-    
+
     root.insert("DoubleArray", double_array);
-    
+
     auto string_array = std::make_shared<cpptoml::array>();
     string_array->push_back(std::string("A"));
     string_array->push_back(std::string("B"));
     string_array->push_back(std::string("C"));
     string_array->push_back(std::string("D"));
     string_array->push_back(std::string("E"));
-    
+
     root.insert("StringArray", string_array);
-    
+
     auto table_array = std::make_shared<cpptoml::table_array>();
     table_array->push_back(table);
     table_array->push_back(table);
     table_array->push_back(table);
-    
+
     root.insert("TableArray", table_array);
-    
+
     auto array_of_arrays = std::make_shared<cpptoml::array>();
     array_of_arrays->push_back(int_array);
     array_of_arrays->push_back(double_array);
     array_of_arrays->push_back(string_array);
-    
+
     root.insert("ArrayOfArrays", array_of_arrays);
-    
+
     std::cout << root;
     return 0;
 }

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -2110,6 +2110,7 @@ class toml_writer
      */
     void write(const value<double>& v)
     {
+        stream_ << std::showpoint;
         write(v.get());
     }
 
@@ -2152,7 +2153,18 @@ class toml_writer
                     write(".");
                 }
 
-                write(path_[i]);
+                if (path_[i].find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcde"
+                                               "fghijklmnopqrstuvwxyz0123456789"
+                                               "_-") == std::string::npos)
+                {
+                    write(path_[i]);
+                }
+                else
+                {
+                    write("\"");
+                    write(escape_string(path_[i]));
+                    write("\"");
+                }
             }
 
             if (in_array)
@@ -2173,7 +2185,20 @@ class toml_writer
         if (!b.is_table() && !b.is_table_array())
         {
             indent();
-            write(path_.back());
+
+            if (path_.back().find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcde"
+                                               "fghijklmnopqrstuvwxyz0123456789"
+                                               "_-") == std::string::npos)
+            {
+                write(path_.back());
+            }
+            else
+            {
+                write("\"");
+                write(escape_string(path_.back()));
+                write("\"");
+            }
+
             write(" = ");
         }
     }

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -327,32 +327,32 @@ class array : public base
     {
         return true;
     }
-    
+
     /**
      * arrays can be iterated over
      */
     using iterator = std::vector<std::shared_ptr<base>>::iterator;
-    
+
     /**
      * arrays can be iterated over.  Const version.
      */
     using const_iterator = std::vector<std::shared_ptr<base>>::const_iterator;
-    
+
     iterator begin()
     {
         return values_.begin();
     }
-    
+
     const_iterator begin() const
     {
         return values_.begin();
     }
-    
+
     iterator end()
     {
         return values_.end();
     }
-    
+
     const_iterator end() const
     {
         return values_.end();
@@ -391,8 +391,8 @@ class array : public base
         std::transform(values_.begin(), values_.end(), result.begin(),
                        [&](std::shared_ptr<base> v)
                        {
-                           return v->as<T>();
-                       });
+            return v->as<T>();
+        });
 
         return result;
     }
@@ -408,18 +408,18 @@ class array : public base
         std::transform(values_.begin(), values_.end(), result.begin(),
                        [&](std::shared_ptr<base> v)
                        {
-                           if (v->is_array())
-                               return std::static_pointer_cast<array>(v);
-                           return std::shared_ptr<array>{};
-                       });
+            if (v->is_array())
+                return std::static_pointer_cast<array>(v);
+            return std::shared_ptr<array>{};
+        });
 
         return result;
     }
-    
+
     /**
      * Add a value to the end of the array
      */
-    template<class T>
+    template <class T>
     void push_back(const std::shared_ptr<value<T>>& val)
     {
         if (values_.empty() || values_[0]->as<T>())
@@ -431,7 +431,7 @@ class array : public base
             throw array_exception{"Arrays must be homogenous."};
         }
     }
-    
+
     /**
      * Add an array to the end of the array
      */
@@ -446,21 +446,22 @@ class array : public base
             throw array_exception{"Arrays must be homogenous."};
         }
     }
-    
+
     /**
      * Convenience function for adding a simple element to the end
      * of the array.
      */
-    template<class T>
-    void push_back(const T& val, typename std::enable_if<valid_value<T>::value>::type * = 0)
+    template <class T>
+    void push_back(const T& val,
+                   typename std::enable_if<valid_value<T>::value>::type* = 0)
     {
         push_back(std::make_shared<value<T>>(val));
     }
-    
+
     /**
      * Insert a value into the array
      */
-    template<class T>
+    template <class T>
     iterator insert(iterator position, const std::shared_ptr<value<T>>& value)
     {
         if (values_.empty() || values_[0]->as<T>())
@@ -472,7 +473,7 @@ class array : public base
             throw array_exception{"Arrays must be homogenous."};
         }
     }
-    
+
     /**
      * Insert an array into the array
      */
@@ -487,27 +488,27 @@ class array : public base
             throw array_exception{"Arrays must be homogenous."};
         }
     }
-    
+
     /**
      * Convenience function for inserting a simple element in the array
      */
-    //template<class T>
-    //iterator insert(iterator position, T&& val,
+    // template<class T>
+    // iterator insert(iterator position, T&& val,
     //    typename std::enable_if<valid_value<T>::value>::type* = 0)
     //{
     //    return insert(position, element_factory::create_value(val));
     //}
-    
+
     /**
      * Convenience function for inserting a simple element in the array
      */
-    template<class T>
+    template <class T>
     iterator insert(iterator position, const T& val,
-        typename std::enable_if<valid_value<T>::value>::type* = 0)
+                    typename std::enable_if<valid_value<T>::value>::type* = 0)
     {
         return insert(position, std::make_shared<value<T>>(val));
     }
-    
+
     /**
      * Erase an element from the array
      */
@@ -515,7 +516,7 @@ class array : public base
     {
         return values_.erase(position);
     }
-    
+
     /**
      * Clear the array
      */
@@ -539,32 +540,32 @@ class table_array : public base
      * arrays can be iterated over
      */
     using iterator = std::vector<std::shared_ptr<table>>::iterator;
-    
+
     /**
      * arrays can be iterated over.  Const version.
      */
     using const_iterator = std::vector<std::shared_ptr<table>>::const_iterator;
-    
+
     iterator begin()
     {
         return array_.begin();
     }
-    
+
     const_iterator begin() const
     {
         return array_.begin();
     }
-    
+
     iterator end()
     {
         return array_.end();
     }
-    
+
     const_iterator end() const
     {
         return array_.end();
     }
-    
+
     virtual bool is_table_array() const override
     {
         return true;
@@ -579,7 +580,7 @@ class table_array : public base
     {
         return array_;
     }
-    
+
     /**
      * Add a table to the end of the array
      */
@@ -595,7 +596,7 @@ class table_array : public base
     {
         return array_.insert(position, value);
     }
-    
+
     /**
      * Erase an element from the array
      */
@@ -603,7 +604,7 @@ class table_array : public base
     {
         return array_.erase(position);
     }
-    
+
     /**
      * Clear the array
      */
@@ -979,8 +980,8 @@ class parser
         {
             auto part = parse_key(it, end, [](char c)
                                   {
-                                      return c == '.' || c == ']';
-                                  });
+                return c == '.' || c == ']';
+            });
 
             if (part.empty())
                 throw_parse_exception("Empty component of table name");
@@ -1053,8 +1054,8 @@ class parser
         {
             auto part = parse_key(it, end, [](char c)
                                   {
-                                      return c == '.' || c == ']';
-                                  });
+                return c == '.' || c == ']';
+            });
 
             if (part.empty())
                 throw_parse_exception("Empty component of table array name");
@@ -1139,8 +1140,8 @@ class parser
     {
         auto key = parse_key(it, end, [](char c)
                              {
-                                 return c == '=';
-                             });
+            return c == '=';
+        });
         if (curr_table->contains(key))
             throw_parse_exception("Key " + key + " already present");
         if (*it != '=')
@@ -1188,8 +1189,8 @@ class parser
 
         if (std::find_if(it, key_end, [](char c)
                          {
-                             return c == ' ' || c == '\t';
-                         }) != key_end)
+                return c == ' ' || c == '\t';
+            }) != key_end)
         {
             throw_parse_exception("Bare key " + key
                                   + " cannot contain whitespace");
@@ -1197,8 +1198,8 @@ class parser
 
         if (std::find_if(it, key_end, [](char c)
                          {
-                             return c == '[' || c == ']';
-                         }) != key_end)
+                return c == '[' || c == ']';
+            }) != key_end)
         {
             throw_parse_exception("Bare key " + key
                                   + " cannot contain '[' or ']'");
@@ -1595,9 +1596,8 @@ class parser
     {
         auto boolend = std::find_if(it, end, [](char c)
                                     {
-                                        return c == ' ' || c == '\t'
-                                               || c == '#';
-                                    });
+            return c == ' ' || c == '\t' || c == '#';
+        });
         std::string v{it, boolend};
         it = boolend;
         if (v == "true")
@@ -1613,10 +1613,9 @@ class parser
     {
         return std::find_if(it, end, [this](char c)
                             {
-                                return !is_number(c) && c != 'T' && c != 'Z'
-                                       && c != ':' && c != '-' && c != '+'
-                                       && c != '.';
-                            });
+            return !is_number(c) && c != 'T' && c != 'Z' && c != ':' && c != '-'
+                   && c != '+' && c != '.';
+        });
     }
 
     std::shared_ptr<value<datetime>>
@@ -1714,8 +1713,8 @@ class parser
 
         auto val_end = std::find_if(it, end, [](char c)
                                     {
-                                        return c == ',' || c == ']' || c == '#';
-                                    });
+            return c == ',' || c == ']' || c == '#';
+        });
         parse_type type = determine_value_type(it, val_end);
         switch (type)
         {

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -82,6 +82,37 @@ struct datetime
     int microsecond = 0;
     int hour_offset = 0;
     int minute_offset = 0;
+    
+    static inline struct datetime from_local(const struct tm &t)
+    {
+        datetime dt;
+        dt.year = t.tm_year + 1900;
+        dt.month = t.tm_mon + 1;
+        dt.day = t.tm_mday;
+        dt.hour = t.tm_hour;
+        dt.minute = t.tm_min;
+        dt.second = t.tm_sec;
+        
+        char buf[16];
+        strftime(buf, 16, "%z", &t);
+        
+        int offset = std::stoi(buf);
+        dt.hour_offset = offset / 100;
+        dt.minute_offset = offset % 100;
+        return dt;
+    }
+    
+    static inline struct datetime from_utc(const struct tm& t)
+    {
+        datetime dt;
+        dt.year = t.tm_year + 1900;
+        dt.month = t.tm_mon + 1;
+        dt.day = t.tm_mday;
+        dt.hour = t.tm_hour;
+        dt.minute = t.tm_min;
+        dt.second = t.tm_sec;
+        return dt;
+    }
 };
 
 inline std::ostream& operator<<(std::ostream& os, const datetime& dt)

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -300,6 +300,17 @@ inline std::shared_ptr<const value<double>> base::as() const
     return nullptr;
 }
 
+/**
+ * Exception class for array insertion errors.
+ */
+class array_exception : public std::runtime_error
+{
+  public:
+    array_exception(const std::string& err) : std::runtime_error{err}
+    {
+    }
+};
+
 class array : public base
 {
   public:
@@ -315,6 +326,36 @@ class array : public base
     virtual bool is_array() const override
     {
         return true;
+    }
+    
+    /**
+     * arrays can be iterated over
+     */
+    using iterator = std::vector<std::shared_ptr<base>>::iterator;
+    
+    /**
+     * arrays can be iterated over.  Const version.
+     */
+    using const_iterator = std::vector<std::shared_ptr<base>>::const_iterator;
+    
+    iterator begin()
+    {
+        return values_.begin();
+    }
+    
+    const_iterator begin() const
+    {
+        return values_.begin();
+    }
+    
+    iterator end()
+    {
+        return values_.end();
+    }
+    
+    const_iterator end() const
+    {
+        return values_.end();
     }
 
     /**
@@ -374,6 +415,114 @@ class array : public base
 
         return result;
     }
+    
+    /**
+     * Add a value to the end of the array
+     */
+    template<class T>
+    void push_back(const std::shared_ptr<value<T>>& val)
+    {
+        if (values_.empty() || values_[0]->as<T>())
+        {
+            values_.push_back(val);
+        }
+        else
+        {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+    
+    /**
+     * Add an array to the end of the array
+     */
+    void push_back(const std::shared_ptr<array>& val)
+    {
+        if (values_.empty() || values_[0]->is_array())
+        {
+            values_.push_back(val);
+        }
+        else
+        {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+    
+    /**
+     * Convenience function for adding a simple element to the end
+     * of the array.
+     */
+    template<class T>
+    void push_back(const T& val, typename std::enable_if<valid_value<T>::value>::type * = 0)
+    {
+        push_back(std::make_shared<value<T>>(val));
+    }
+    
+    /**
+     * Insert a value into the array
+     */
+    template<class T>
+    iterator insert(iterator position, const std::shared_ptr<value<T>>& value)
+    {
+        if (values_.empty() || values_[0]->as<T>())
+        {
+            return values_.insert(position, value);
+        }
+        else
+        {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+    
+    /**
+     * Insert an array into the array
+     */
+    iterator insert(iterator position, const std::shared_ptr<array>& value)
+    {
+        if (values_.empty() || values_[0]->is_array())
+        {
+            return values_.insert(position, value);
+        }
+        else
+        {
+            throw array_exception{"Arrays must be homogenous."};
+        }
+    }
+    
+    /**
+     * Convenience function for inserting a simple element in the array
+     */
+    //template<class T>
+    //iterator insert(iterator position, T&& val,
+    //    typename std::enable_if<valid_value<T>::value>::type* = 0)
+    //{
+    //    return insert(position, element_factory::create_value(val));
+    //}
+    
+    /**
+     * Convenience function for inserting a simple element in the array
+     */
+    template<class T>
+    iterator insert(iterator position, const T& val,
+        typename std::enable_if<valid_value<T>::value>::type* = 0)
+    {
+        return insert(position, std::make_shared<value<T>>(val));
+    }
+    
+    /**
+     * Erase an element from the array
+     */
+    iterator erase(iterator position)
+    {
+        return values_.erase(position);
+    }
+    
+    /**
+     * Clear the array
+     */
+    void clear()
+    {
+        values_.clear();
+    }
 
   private:
     std::vector<std::shared_ptr<base>> values_;
@@ -386,6 +535,36 @@ class table_array : public base
     friend class table;
 
   public:
+    /**
+     * arrays can be iterated over
+     */
+    using iterator = std::vector<std::shared_ptr<table>>::iterator;
+    
+    /**
+     * arrays can be iterated over.  Const version.
+     */
+    using const_iterator = std::vector<std::shared_ptr<table>>::const_iterator;
+    
+    iterator begin()
+    {
+        return array_.begin();
+    }
+    
+    const_iterator begin() const
+    {
+        return array_.begin();
+    }
+    
+    iterator end()
+    {
+        return array_.end();
+    }
+    
+    const_iterator end() const
+    {
+        return array_.end();
+    }
+    
     virtual bool is_table_array() const override
     {
         return true;
@@ -399,6 +578,38 @@ class table_array : public base
     const std::vector<std::shared_ptr<table>>& get() const
     {
         return array_;
+    }
+    
+    /**
+     * Add a table to the end of the array
+     */
+    void push_back(const std::shared_ptr<table>& val)
+    {
+        array_.push_back(val);
+    }
+
+    /**
+     * Insert a table into the array
+     */
+    iterator insert(iterator position, const std::shared_ptr<table>& value)
+    {
+        return array_.insert(position, value);
+    }
+    
+    /**
+     * Erase an element from the array
+     */
+    iterator erase(iterator position)
+    {
+        return array_.erase(position);
+    }
+    
+    /**
+     * Clear the array
+     */
+    void clear()
+    {
+        array_.clear();
     }
 
   private:
@@ -610,7 +821,7 @@ class table : public base
      * keytable.
      */
     template <class T>
-    void insert(const std::string& key, T&& val,
+    void insert(const std::string& key, const T& val,
                 typename std::enable_if<valid_value<T>::value>::type* = 0)
     {
         insert(key, std::make_shared<value<T>>(val));


### PR DESCRIPTION
* Added iterators to array and table_array
* Added push_back() and insert() function analogous to std::vector to array and table_array
* Created array_exception which is thrown by push_back() and insert() if you try to create a heterogenous array.
* Changed the signature of the convenience table::insert() function so that it plays nicely with valid_value.  The rvalue reference version simply would not work on gcc-4.9.2.  I haven't investigated enough to find out if it is a bug or not, but for now it's been changed to a const & instead of a &&.