### PR TITLE
use nowide::fstream if nowide/fstream.hpp included

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -1677,7 +1677,13 @@ class parser
  */
 inline table parse_file(const std::string& filename)
 {
-    std::ifstream file{filename};
+#if defined(BOOST_NOWIDE_FSTREAM_INCLUDED_HPP)
+	boost::nowide::ifstream file{ filename.c_str() };
+#elif defined(NOWIDE_FSTREAM_INCLUDED_HPP)
+	nowide::ifstream file{ filename.c_str() };
+#else
+	std::ifstream file{ filename };
+#endif
     if (!file.is_open())
         throw parse_exception{filename + " could not be opened for parsing"};
     parser p{file};


### PR DESCRIPTION
On Windows, cpptoml cannot load files that have unicode filenames since it uses ifstream which is a narrow string interface only and doesn't accept wchar filenames. For instance, this fails to open the file test-ש-м-ν.toml when given via parse_file:

> auto root = cpptoml::parse_file("test-\xd7\xa9-\xd0\xbc-\xce\xbd.toml");

Rather than try and hack in some Windows-specific code with ifdefs, I thought it'd be cleaner to just use boost.nowide (or the standalone libnowide) to allow UTF-8 filenames to be specified and opened correctly on Windows using the standard narrow interfaces used on every other platform.

No dependency is added to the code. It checks for the include header guard definition to see whether <nowide/fstream.hpp> is already loaded and uses the nowide fstream class if it is.

> #include \<nowide/fstream.hpp\> //include before cpptoml
> #include \<cpptoml.h\>