### PR TITLE
Forcing use of make_value, make_table, make_array, etc.

### DIFF
--- a/build_toml.cpp
+++ b/build_toml.cpp
@@ -3,66 +3,66 @@
 
 int main(int argc, char* argv[])
 {
-    cpptoml::table root;
-    root.insert("Integer", 1234L);
-    root.insert("Double", 1.234);
-    root.insert("String", std::string("ABCD"));
+    std::shared_ptr<cpptoml::table> root = cpptoml::make_table();
+    root->insert("Integer", 1234L);
+    root->insert("Double", 1.234);
+    root->insert("String", std::string("ABCD"));
 
-    auto table = std::make_shared<cpptoml::table>();
+    auto table = cpptoml::make_table();
     table->insert("ElementOne", 1L);
     table->insert("ElementTwo", 2.0);
     table->insert("ElementThree", std::string("THREE"));
 
-    auto nested_table = std::make_shared<cpptoml::table>();
+    auto nested_table = cpptoml::make_table();
     nested_table->insert("ElementOne", 2L);
     nested_table->insert("ElementTwo", 3.0);
     nested_table->insert("ElementThree", std::string("FOUR"));
 
     table->insert("Nested", nested_table);
 
-    root.insert("Table", table);
+    root->insert("Table", table);
 
-    auto int_array = std::make_shared<cpptoml::array>();
+    auto int_array = cpptoml::make_array();
     int_array->push_back(1L);
     int_array->push_back(2L);
     int_array->push_back(3L);
     int_array->push_back(4L);
     int_array->push_back(5L);
 
-    root.insert("IntegerArray", int_array);
+    root->insert("IntegerArray", int_array);
 
-    auto double_array = std::make_shared<cpptoml::array>();
+    auto double_array = cpptoml::make_array();
     double_array->push_back(1.1);
     double_array->push_back(2.2);
     double_array->push_back(3.3);
     double_array->push_back(4.4);
     double_array->push_back(5.5);
 
-    root.insert("DoubleArray", double_array);
+    root->insert("DoubleArray", double_array);
 
-    auto string_array = std::make_shared<cpptoml::array>();
+    auto string_array = cpptoml::make_array();
     string_array->push_back(std::string("A"));
     string_array->push_back(std::string("B"));
     string_array->push_back(std::string("C"));
     string_array->push_back(std::string("D"));
     string_array->push_back(std::string("E"));
 
-    root.insert("StringArray", string_array);
+    root->insert("StringArray", string_array);
 
-    auto table_array = std::make_shared<cpptoml::table_array>();
+    auto table_array = cpptoml::make_table_array();
     table_array->push_back(table);
     table_array->push_back(table);
     table_array->push_back(table);
 
-    root.insert("TableArray", table_array);
+    root->insert("TableArray", table_array);
 
-    auto array_of_arrays = std::make_shared<cpptoml::array>();
+    auto array_of_arrays = cpptoml::make_array();
     array_of_arrays->push_back(int_array);
     array_of_arrays->push_back(double_array);
     array_of_arrays->push_back(string_array);
 
-    root.insert("ArrayOfArrays", array_of_arrays);
+    root->insert("ArrayOfArrays", array_of_arrays);
 
-    std::cout << root;
+    std::cout << (*root);
     return 0;
 }

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -157,9 +157,44 @@ inline std::ostream& operator<<(std::ostream& os, const datetime& dt)
 template <class T>
 class value;
 
+template <class T>
+struct valid_value
+{
+    const static bool value
+        = std::is_same<T, std::string>::value || std::is_same<T, int64_t>::value
+          || std::is_same<T, double>::value || std::is_same<T, bool>::value
+          || std::is_same<T, datetime>::value;
+};
+
+template <class T, bool Valid = valid_value<typename std::decay<T>::type>::value
+                                || std::is_convertible<T, std::string>::value>
+struct value_traits;
+
+template <class T>
+struct value_traits<T, true>
+{
+    const static bool valid = valid_value<typename std::decay<T>::type>::value
+                              || std::is_convertible<T, std::string>::value;
+
+    using value_type = typename std::
+        conditional<valid_value<typename std::decay<T>::type>::value,
+                    typename std::decay<T>::type, std::string>::type;
+
+    using type = value<value_type>;
+};
+
 class array;
 class table;
 class table_array;
+
+template <class T>
+inline std::shared_ptr<typename value_traits<T>::type>
+    make_value(T&& val, typename value_traits<T>::type* = 0);
+inline std::shared_ptr<array> make_array();
+template <class T>
+inline std::shared_ptr<T> make_element();
+inline std::shared_ptr<table> make_table();
+inline std::shared_ptr<table_array> make_table_array();
 
 /**
  * A generic base TOML value used for type erasure.
@@ -240,32 +275,12 @@ class base : public std::enable_shared_from_this<base>
 
     template <class Visitor, class... Args>
     void accept(Visitor&& visitor, Args&&... args) const;
-};
 
-template <class T>
-struct valid_value
-{
-    const static bool value
-        = std::is_same<T, std::string>::value || std::is_same<T, int64_t>::value
-          || std::is_same<T, double>::value || std::is_same<T, bool>::value
-          || std::is_same<T, datetime>::value;
-};
-
-template <class T, bool Valid = valid_value<typename std::decay<T>::type>::value
-                                || std::is_convertible<T, std::string>::value>
-struct value_traits;
-
-template <class T>
-struct value_traits<T, true>
-{
-    const static bool valid = valid_value<typename std::decay<T>::type>::value
-                              || std::is_convertible<T, std::string>::value;
-
-    using value_type = typename std::
-        conditional<valid_value<typename std::decay<T>::type>::value,
-                    typename std::decay<T>::type, std::string>::type;
-
-    using type = value<value_type>;
+  protected:
+    base()
+    {
+        // nothing
+    }
 };
 
 /**
@@ -274,15 +289,17 @@ struct value_traits<T, true>
 template <class T>
 class value : public base
 {
+    friend std::shared_ptr<typename value_traits<T>::type>
+        cpptoml::make_value<>(T&& val, typename value_traits<T>::type*);
+
+    friend std::shared_ptr<typename value_traits<T>::type>
+        cpptoml::make_value<>(T& val, typename value_traits<T>::type*);
+
+    friend std::shared_ptr<typename value_traits<T>::type>
+        cpptoml::make_value<>(const T& val, typename value_traits<T>::type*);
+
   public:
     static_assert(valid_value<T>::value, "invalid value type");
-
-    /**
-     * Constructs a value from the given data.
-     */
-    value(const T& val) : data_(val)
-    {
-    }
 
     bool is_value() const override
     {
@@ -307,7 +324,26 @@ class value : public base
 
   private:
     T data_;
+
+    /**
+     * Constructs a value from the given data.
+     */
+    value(const T& val) : data_(val)
+    {
+    }
+
+    value(const value& val) = delete;
+    value& operator=(const value& val) = delete;
 };
+
+template <class T>
+inline std::shared_ptr<typename value_traits<T>::type>
+    make_value(T&& val, typename value_traits<T>::type*)
+{
+    typedef std::shared_ptr<typename value_traits<T>::type> pointer_type;
+    return pointer_type(
+        new typename pointer_type::element_type(std::forward<T>(val)));
+}
 
 template <class T>
 inline std::shared_ptr<value<T>> base::as()
@@ -326,7 +362,7 @@ inline std::shared_ptr<value<double>> base::as()
         return v;
 
     if (auto v = std::dynamic_pointer_cast<value<int64_t>>(shared_from_this()))
-        return std::make_shared<value<double>>(v->get());
+        return make_value<double>(v->get());
 
     return nullptr;
 }
@@ -352,7 +388,7 @@ inline std::shared_ptr<const value<double>> base::as() const
     {
         // the below has to be a non-const value<double> due to a bug in
         // libc++: https://llvm.org/bugs/show_bug.cgi?id=18843
-        return std::make_shared<value<double>>(v->get());
+        return make_value<double>(v->get());
     }
 
     return nullptr;
@@ -372,14 +408,7 @@ class array_exception : public std::runtime_error
 class array : public base
 {
   public:
-    array() = default;
-
-    template <class InputIterator>
-    array(InputIterator begin, InputIterator end)
-        : values_{begin, end}
-    {
-        // nothing
-    }
+    friend std::shared_ptr<array> make_array();
 
     virtual bool is_array() const override
     {
@@ -512,8 +541,7 @@ class array : public base
     template <class T>
     void push_back(T&& val, typename value_traits<T>::type* = 0)
     {
-        push_back(std::make_shared<typename value_traits<T>::type>(
-            std::forward<T>(val)));
+        push_back(make_value(std::forward<T>(val)));
     }
 
     /**
@@ -554,9 +582,7 @@ class array : public base
     iterator insert(iterator position, T&& val,
                     typename value_traits<T>::type* = 0)
     {
-        return insert(position,
-                      std::make_shared<typename value_traits<T>::type>(
-                          std::forward<T>(val)));
+        return insert(position, make_value(std::forward<T>(val)));
     }
 
     /**
@@ -576,14 +602,38 @@ class array : public base
     }
 
   private:
+    array() = default;
+
+    template <class InputIterator>
+    array(InputIterator begin, InputIterator end)
+        : values_{begin, end}
+    {
+        // nothing
+    }
+
+    array(const array& obj) = delete;
+    array& operator=(const array& obj) = delete;
+
     std::vector<std::shared_ptr<base>> values_;
 };
+
+inline std::shared_ptr<array> make_array()
+{
+    return std::shared_ptr<array>(new array());
+}
+
+template <>
+inline std::shared_ptr<array> make_element<array>()
+{
+    return make_array();
+}
 
 class table;
 
 class table_array : public base
 {
     friend class table;
+    friend std::shared_ptr<table_array> make_table_array();
 
   public:
     /**
@@ -664,8 +714,27 @@ class table_array : public base
     }
 
   private:
+    table_array()
+    {
+        // nothing
+    }
+
+    table_array(const table_array& obj) = delete;
+    table_array& operator=(const table_array& rhs) = delete;
+
     std::vector<std::shared_ptr<table>> array_;
 };
+
+inline std::shared_ptr<table_array> make_table_array()
+{
+    return std::shared_ptr<table_array>(new table_array());
+}
+
+template <>
+inline std::shared_ptr<table_array> make_element<table_array>()
+{
+    return make_table_array();
+}
 
 /**
  * Represents a TOML keytable.
@@ -674,6 +743,8 @@ class table : public base
 {
   public:
     friend class table_array;
+    friend std::shared_ptr<table> make_table();
+
     /**
      * tables can be iterated over.
      */
@@ -875,11 +946,18 @@ class table : public base
     void insert(const std::string& key, T&& val,
                 typename value_traits<T>::type* = 0)
     {
-        insert(key, std::make_shared<typename value_traits<T>::type>(
-                        std::forward<T>(val)));
+        insert(key, make_value(std::forward<T>(val)));
     }
 
   private:
+    table()
+    {
+        // nothing
+    }
+
+    table(const table& obj) = delete;
+    table& operator=(const table& rhs) = delete;
+
     std::vector<std::string> split(const std::string& value,
                                    char separator) const
     {
@@ -930,6 +1008,17 @@ class table : public base
     string_to_base_map map_;
 };
 
+std::shared_ptr<table> make_table()
+{
+    return std::shared_ptr<table>(new table());
+}
+
+template <>
+inline std::shared_ptr<table> make_element<table>()
+{
+    return make_table();
+}
+
 /**
  * Exception class for all TOML parsing errors.
  */
@@ -965,11 +1054,11 @@ class parser
      * Parses the stream this parser was created on until EOF.
      * @throw parse_exception if there are errors in parsing
      */
-    table parse()
+    std::shared_ptr<table> parse()
     {
-        table root;
+        std::shared_ptr<table> root = make_table();
 
-        table* curr_table = &root;
+        table* curr_table = root.get();
 
         while (std::getline(input_, line_))
         {
@@ -981,7 +1070,7 @@ class parser
                 continue;
             if (*it == '[')
             {
-                curr_table = &root;
+                curr_table = root.get();
                 parse_table(it, end, curr_table);
             }
             else
@@ -1058,7 +1147,7 @@ class parser
             else
             {
                 inserted = true;
-                curr_table->insert(part, std::make_shared<table>());
+                curr_table->insert(part, make_table());
                 curr_table = static_cast<table*>(curr_table->get(part).get());
             }
             consume_whitespace(it, end);
@@ -1132,7 +1221,7 @@ class parser
                         throw_parse_exception("Key " + full_ta_name
                                               + " is not a table array");
                     auto v = b->as_table_array();
-                    v->get().push_back(std::make_shared<table>());
+                    v->get().push_back(make_table());
                     curr_table = v->get().back().get();
                 }
                 // otherwise, just keep traversing down the key name
@@ -1157,17 +1246,17 @@ class parser
                 // add keys to next
                 if (it != end && *it == ']')
                 {
-                    curr_table->insert(part, std::make_shared<table_array>());
+                    curr_table->insert(part, make_table_array());
                     auto arr = std::static_pointer_cast<table_array>(
                         curr_table->get(part));
-                    arr->get().push_back(std::make_shared<table>());
+                    arr->get().push_back(make_table());
                     curr_table = arr->get().back().get();
                 }
                 // otherwise, create the implicitly defined table and move
                 // down to it
                 else
                 {
-                    curr_table->insert(part, std::make_shared<table>());
+                    curr_table->insert(part, make_table());
                     curr_table
                         = static_cast<table*>(curr_table->get(part).get());
                 }
@@ -1372,8 +1461,7 @@ class parser
                 return parse_multiline_string(it, end, delim);
             }
         }
-        return std::make_shared<value<std::string>>(
-            string_literal(it, end, delim));
+        return make_value<std::string>(string_literal(it, end, delim));
     }
 
     std::shared_ptr<value<std::string>>
@@ -1432,7 +1520,7 @@ class parser
                         && *check++ == delim)
                     {
                         it = check;
-                        ret = std::make_shared<value<std::string>>(ss.str());
+                        ret = make_value<std::string>(ss.str());
                         break;
                     }
                 }
@@ -1606,7 +1694,7 @@ class parser
         it = end;
         try
         {
-            return std::make_shared<value<int64_t>>(std::stoll(v));
+            return make_value<int64_t>(std::stoll(v));
         }
         catch (const std::invalid_argument& ex)
         {
@@ -1628,7 +1716,7 @@ class parser
         it = end;
         try
         {
-            return std::make_shared<value<double>>(std::stold(v));
+            return make_value<double>(std::stold(v));
         }
         catch (const std::invalid_argument& ex)
         {
@@ -1652,9 +1740,9 @@ class parser
         std::string v{it, boolend};
         it = boolend;
         if (v == "true")
-            return std::make_shared<value<bool>>(true);
+            return make_value<bool>(true);
         else if (v == "false")
-            return std::make_shared<value<bool>>(false);
+            return make_value<bool>(false);
         else
             throw_parse_exception("Attempted to parse invalid boolean value");
     }
@@ -1738,7 +1826,7 @@ class parser
         if (it != date_end)
             throw_parse_exception("Malformed date");
 
-        return std::make_shared<value<datetime>>(dt);
+        return make_value(dt);
     }
 
     std::shared_ptr<base> parse_array(std::string::iterator& it,
@@ -1759,7 +1847,7 @@ class parser
         if (*it == ']')
         {
             ++it;
-            return std::make_shared<array>();
+            return make_array();
         }
 
         auto val_end = std::find_if(it, end, [](char c)
@@ -1792,7 +1880,7 @@ class parser
     std::shared_ptr<array> parse_value_array(std::string::iterator& it,
                                              std::string::iterator& end)
     {
-        auto arr = std::make_shared<array>();
+        auto arr = make_array();
         while (it != end && *it != ']')
         {
             auto value = parse_value(it, end);
@@ -1816,7 +1904,7 @@ class parser
                                                std::string::iterator& it,
                                                std::string::iterator& end)
     {
-        auto arr = std::make_shared<Object>();
+        auto arr = make_element<Object>();
 
         while (it != end && *it != ']')
         {
@@ -1843,7 +1931,7 @@ class parser
     std::shared_ptr<table> parse_inline_table(std::string::iterator& it,
                                               std::string::iterator& end)
     {
-        auto tbl = std::make_shared<table>();
+        auto tbl = make_table();
         do
         {
             ++it;
@@ -1936,7 +2024,7 @@ class parser
  * Utility function to parse a file as a TOML file. Returns the root table.
  * Throws a parse_exception if the file cannot be opened.
  */
-inline table parse_file(const std::string& filename)
+inline std::shared_ptr<table> parse_file(const std::string& filename)
 {
 #if defined(BOOST_NOWIDE_FSTREAM_INCLUDED_HPP)
     boost::nowide::ifstream file{filename.c_str()};

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -288,14 +288,9 @@ class base : public std::enable_shared_from_this<base>
 template <class T>
 class value : public base
 {
-    friend std::shared_ptr<typename value_traits<T>::type>
-        cpptoml::make_value<>(T&& val);
-
-    friend std::shared_ptr<typename value_traits<T>::type>
-        cpptoml::make_value<>(T& val);
-
-    friend std::shared_ptr<typename value_traits<T>::type>
-        cpptoml::make_value<>(const T& val);
+    template <class U>
+    friend std::shared_ptr<typename value_traits<U>::type>
+        cpptoml::make_value(U&& val);
 
   public:
     static_assert(valid_value<T>::value, "invalid value type");
@@ -336,11 +331,17 @@ class value : public base
 };
 
 template <class T>
-inline std::shared_ptr<typename value_traits<T>::type> make_value(T&& val)
+std::shared_ptr<typename value_traits<T>::type> make_value(T&& val)
 {
-    typedef std::shared_ptr<typename value_traits<T>::type> pointer_type;
-    return pointer_type(
-        new typename pointer_type::element_type(std::forward<T>(val)));
+    using value_type = typename value_traits<T>::type;
+    struct make_shared_enabler : public value_type
+    {
+        make_shared_enabler(T&& val) : value_type(std::forward<T>(val))
+        {
+            // nothing
+        }
+    };
+    return std::make_shared<make_shared_enabler>(std::forward<T>(val));
 }
 
 template <class T>
@@ -617,7 +618,15 @@ class array : public base
 
 inline std::shared_ptr<array> make_array()
 {
-    return std::shared_ptr<array>(new array());
+    struct make_shared_enabler : public array
+    {
+        make_shared_enabler()
+        {
+            // nothing
+        }
+    };
+
+    return std::make_shared<make_shared_enabler>();
 }
 
 template <>
@@ -725,7 +734,15 @@ class table_array : public base
 
 inline std::shared_ptr<table_array> make_table_array()
 {
-    return std::shared_ptr<table_array>(new table_array());
+    struct make_shared_enabler : public table_array
+    {
+        make_shared_enabler()
+        {
+            // nothing
+        }
+    };
+
+    return std::make_shared<make_shared_enabler>();
 }
 
 template <>
@@ -1008,7 +1025,15 @@ class table : public base
 
 std::shared_ptr<table> make_table()
 {
-    return std::shared_ptr<table>(new table());
+    struct make_shared_enabler : public table
+    {
+        make_shared_enabler()
+        {
+            // nothing
+        }
+    };
+
+    return std::make_shared<make_shared_enabler>();
 }
 
 template <>

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -188,8 +188,7 @@ class table;
 class table_array;
 
 template <class T>
-inline std::shared_ptr<typename value_traits<T>::type>
-    make_value(T&& val, typename value_traits<T>::type* = 0);
+inline std::shared_ptr<typename value_traits<T>::type> make_value(T&& val);
 inline std::shared_ptr<array> make_array();
 template <class T>
 inline std::shared_ptr<T> make_element();
@@ -290,13 +289,13 @@ template <class T>
 class value : public base
 {
     friend std::shared_ptr<typename value_traits<T>::type>
-        cpptoml::make_value<>(T&& val, typename value_traits<T>::type*);
+        cpptoml::make_value<>(T&& val);
 
     friend std::shared_ptr<typename value_traits<T>::type>
-        cpptoml::make_value<>(T& val, typename value_traits<T>::type*);
+        cpptoml::make_value<>(T& val);
 
     friend std::shared_ptr<typename value_traits<T>::type>
-        cpptoml::make_value<>(const T& val, typename value_traits<T>::type*);
+        cpptoml::make_value<>(const T& val);
 
   public:
     static_assert(valid_value<T>::value, "invalid value type");
@@ -337,8 +336,7 @@ class value : public base
 };
 
 template <class T>
-inline std::shared_ptr<typename value_traits<T>::type>
-    make_value(T&& val, typename value_traits<T>::type*)
+inline std::shared_ptr<typename value_traits<T>::type> make_value(T&& val)
 {
     typedef std::shared_ptr<typename value_traits<T>::type> pointer_type;
     return pointer_type(

--- a/parse.cpp
+++ b/parse.cpp
@@ -13,8 +13,8 @@ int main(int argc, char** argv)
 
     try
     {
-        cpptoml::table g = cpptoml::parse_file(argv[1]);
-        std::cout << g << std::endl;
+        std::shared_ptr<cpptoml::table> g = cpptoml::parse_file(argv[1]);
+        std::cout << (*g) << std::endl;
     }
     catch (const cpptoml::parse_exception& e)
     {

--- a/parse_stdin.cpp
+++ b/parse_stdin.cpp
@@ -109,9 +109,9 @@ int main()
     cpptoml::parser p{std::cin};
     try
     {
-        cpptoml::table g = p.parse();
+        std::shared_ptr<cpptoml::table> g = p.parse();
         toml_test_writer writer{std::cout};
-        g.accept(writer);
+        g->accept(writer);
         std::cout << std::endl;
     }
     catch (const cpptoml::parse_exception& ex)


### PR DESCRIPTION
Because of `std::enable_shared_from_this` created factory functions `make_value`, `make_array`, `make_table`, and `make_table_array` to force the user to create `shared_ptr<ELEMENT>`.

Additionally this changes the return value of `parser::parse()` and `parse_file()` to `std::shared_ptr<table>`.

This cleans up the interface and prevents user error when creating `cpptoml` documents in code.