### PR TITLE
Fix clang -Wlambda-extensions warning for a multi-statement lambda

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -492,7 +492,7 @@ class array : public base
         std::vector<std::shared_ptr<array>> result(values_.size());
 
         std::transform(values_.begin(), values_.end(), result.begin(),
-                       [&](std::shared_ptr<base> v)
+                       [&](std::shared_ptr<base> v) -> std::shared_ptr<array>
                        {
             if (v->is_array())
                 return std::static_pointer_cast<array>(v);


### PR DESCRIPTION
clang gives a rather self-explanatory warning for this code:

warning: C++11 requires lambda with omitted result type to consist of a single
return statement [-Wlambda-extensions]

So just add the return type to avoid it (alternative would be to use a ternary
operator to avoid having multiple statements in the first place).