### PR TITLE
Define CPPTOML_DEPRECATED macro appropriately for VS2017

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -28,7 +28,10 @@
 #elif defined(__GNUG__)
 #define CPPTOML_DEPRECATED(reason) __attribute__((deprecated))
 #elif defined(_MSC_VER)
+#if _MSC_VER < 1910
 #define CPPTOML_DEPRECATED(reason) __declspec(deprecated)
+#else
+#define CPPTOML_DEPRECATED(reason) [[deprecated(reason)]]
 #endif
 
 namespace cpptoml

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -33,6 +33,7 @@
 #else
 #define CPPTOML_DEPRECATED(reason) [[deprecated(reason)]]
 #endif
+#endif
 
 namespace cpptoml
 {


### PR DESCRIPTION
The latest iteration of MSVC is fully C++14 conformant, and so should use `[[deprecated(reason)]]` and _not_ `__declspec(deprecated)`.