### PR TITLE
Fix compile error on Windows with VS2015.

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -156,9 +156,9 @@ struct offset_datetime : local_datetime, zone_offset
     }
 };
 
-using datetime
+typedef offset_datetime
     CPPTOML_DEPRECATED("datetime has been renamed to offset_datetime")
-    = offset_datetime;
+    datetime;
 
 class fill_guard
 {


### PR DESCRIPTION
Fix following error on Windows:

cpptoml\include\cpptoml.h(161): error C2059: syntax error: '' [C:\at-ws\3rdparty\cpptoml\BUILD\examples\parse.vcxproj]