### PR TITLE
Fix unsigned comparison (fixes #69)

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -3060,7 +3060,7 @@ class toml_writer
             {
                 res += "\\\\";
             }
-            else if (*it >= 0x0000 && *it <= 0x001f)
+            else if ((const uint32_t)*it <= 0x001f)
             {
                 res += "\\u";
                 std::stringstream ss;


### PR DESCRIPTION
The `auto` keyword seems to be assigned to a `std::string::const_iterator` which is in fact a `const char`.

But the unqualified `char` signed-ness is undefined and implementation specific.

Explicitly casting the iterator fixes this warning.