### PR TITLE
Changed exception when file could not be opened

### DIFF
--- a/examples/parse.cpp
+++ b/examples/parse.cpp
@@ -21,6 +21,10 @@ int main(int argc, char** argv)
         std::cerr << "Failed to parse " << argv[1] << ": " << e.what() << std::endl;
         return 1;
     }
+    catch (const std::invalid_argument& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
 
     return 0;
 }

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -2836,7 +2836,7 @@ class parser
 
 /**
  * Utility function to parse a file as a TOML file. Returns the root table.
- * Throws a parse_exception if the file cannot be opened.
+ * Throws a std::invalid_argument if the file cannot be opened.
  */
 inline std::shared_ptr<table> parse_file(const std::string& filename)
 {
@@ -2848,7 +2848,7 @@ inline std::shared_ptr<table> parse_file(const std::string& filename)
     std::ifstream file{filename};
 #endif
     if (!file.is_open())
-        throw parse_exception{filename + " could not be opened for parsing"};
+        throw std::invalid_argument {filename + " could not be opened for parsing"};
     parser p{file};
     return p.parse();
 }


### PR DESCRIPTION
Hi,

I changed the exception when the file to be parsed cannot be opened to std::invalid_argument.

I believe std::invalid_argument is more meaningful because it's not really a parsing error, if the file could not be opened and nothing has been parsed.

What do you think?