### PR TITLE
Store type information with `base` class to allow use of cpptoml with RTTI disabled

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -396,6 +396,19 @@ inline std::shared_ptr<T> make_element();
 inline std::shared_ptr<table> make_table();
 inline std::shared_ptr<table_array> make_table_array();
 
+enum class base_type
+{
+    NONE,
+    STRING,
+    LOCAL_TIME,
+    LOCAL_DATE,
+    LOCAL_DATETIME,
+    OFFSET_DATETIME,
+    INT,
+    FLOAT,
+    BOOL
+};
+
 /**
  * A generic base TOML value used for type erasure.
  */
@@ -480,11 +493,19 @@ class base : public std::enable_shared_from_this<base>
     template <class Visitor, class... Args>
     void accept(Visitor&& visitor, Args&&... args) const;
 
+    base_type type() const
+    {
+      return type_;
+    }
+
   protected:
-    base()
+    base(const base_type t = base_type::NONE) : type_(t)
     {
         // nothing
     }
+
+  private:
+    const base_type type_ = base_type::NONE;
 };
 
 /**

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -406,7 +406,81 @@ enum class base_type
     OFFSET_DATETIME,
     INT,
     FLOAT,
-    BOOL
+    BOOL,
+    TABLE,
+    ARRAY,
+    TABLE_ARRAY
+};
+    // : is_one_of<T, std::string, int64_t, double, bool, local_date, local_time,
+    //             local_datetime, offset_datetime>
+
+template <class T>
+struct base_type_traits;
+
+template <>
+struct base_type_traits<std::string>
+{
+    static const base_type type = base_type::STRING;
+};
+
+template <>
+struct base_type_traits<local_time>
+{
+    static const base_type type = base_type::LOCAL_TIME;
+};
+
+template <>
+struct base_type_traits<local_date>
+{
+    static const base_type type = base_type::LOCAL_DATE;
+};
+
+template <>
+struct base_type_traits<local_datetime>
+{
+    static const base_type type = base_type::LOCAL_DATETIME;
+};
+
+template <>
+struct base_type_traits<offset_datetime>
+{
+    static const base_type type = base_type::OFFSET_DATETIME;
+};
+
+template <>
+struct base_type_traits<int64_t>
+{
+    static const base_type type = base_type::INT;
+};
+
+template <>
+struct base_type_traits<double>
+{
+    static const base_type type = base_type::FLOAT;
+};
+
+template <>
+struct base_type_traits<bool>
+{
+    static const base_type type = base_type::BOOL;
+};
+
+template <>
+struct base_type_traits<table>
+{
+    static const base_type type = base_type::TABLE;
+};
+
+template <>
+struct base_type_traits<array>
+{
+    static const base_type type = base_type::ARRAY;
+};
+
+template <>
+struct base_type_traits<table_array>
+{
+    static const base_type type = base_type::TABLE_ARRAY;
 };
 
 /**
@@ -499,7 +573,7 @@ class base : public std::enable_shared_from_this<base>
     }
 
   protected:
-    base(const base_type t = base_type::NONE) : type_(t)
+    base(const base_type t) : type_(t)
     {
         // nothing
     }
@@ -561,7 +635,7 @@ class value : public base
     /**
      * Constructs a value from the given data.
      */
-    value(const T& val) : data_(val)
+    value(const T& val) : base(base_type_traits<T>::type), data_(val)
     {
     }
 
@@ -860,7 +934,10 @@ class array : public base
     }
 
   private:
-    array() = default;
+    array() : base(base_type::ARRAY)
+    {
+        // empty
+    }
 
     template <class InputIterator>
     array(InputIterator begin, InputIterator end) : values_{begin, end}
@@ -1013,7 +1090,7 @@ class table_array : public base
     }
 
   private:
-    table_array()
+    table_array() : base(base_type::TABLE_ARRAY)
     {
         // nothing
     }
@@ -1390,7 +1467,7 @@ class table : public base
     }
 
   private:
-    table()
+    table() : base(base_type::TABLE)
     {
         // nothing
     }


### PR DESCRIPTION
This PR adds type information to the `base` class in form of a `base_type` enum class, which is stored in `type_` and accessed by `type()`. That way, it is possible to avoid using RTTI, as all calls to `std::dynamic_pointer_cast` can be replaced by calls to `std::static_pointer_cast`. By default, the original behavior is retained, and the non-RTTI code is only activated when `CPPTOML_NO_RTTI` is defined.

Tested with clang 6.0.0 and g++ 7.2.0 and `-fno-rtti`. Also fixes #52.

@skystrife Sorry for being so brash by coming with these PRs out of the cold. Since I use your library for a scientific HPC project where RTTI and exceptions are disabled, I needed these modifications myself and thought that there would be no harm in sharing them.