### PR TITLE
Fix compilation issues for PGI compiler

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -1928,7 +1928,12 @@ class parser
 
             if (curr_table->contains(part))
             {
+#if !defined(__PGI)
                 auto b = curr_table->get(part);
+#else
+                // Workaround for PGI compiler
+                std::shared_ptr<base> b = curr_table->get(part);
+#endif
                 if (b->is_table())
                     curr_table = static_cast<table*>(b.get());
                 else if (b->is_table_array())
@@ -2009,7 +2014,12 @@ class parser
 
             if (curr_table->contains(part))
             {
+#if !defined(__PGI)
                 auto b = curr_table->get(part);
+#else
+                // Workaround for PGI compiler
+                std::shared_ptr<base> b = curr_table->get(part);
+#endif
 
                 // if this is the end of the table array name, add an
                 // element to the table array that we just looked up

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -2850,9 +2850,9 @@ class parser
         auto arr = make_array();
         while (it != end && *it != ']')
         {
-            auto value = parse_value(it, end);
-            if (auto v = value->as<Value>())
-                arr->get().push_back(value);
+            auto val = parse_value(it, end);
+            if (auto v = val->as<Value>())
+                arr->get().push_back(val);
             else
                 throw_parse_exception("Arrays must be homogeneous");
             skip_whitespace_and_comments(it, end);


### PR DESCRIPTION
This PR fixes two issues the PGI C++ compiler has (at least until version 18.1) when compiling `cpptoml.h`:

* Shadowing class `value` with local variable `value`
* Use of `auto` does sometimes not compile.

These issues seem to be specific to the PGI compiler since they do not occur with other major compilers (GCC, Clang, Intel are fine).