### PR TITLE
Changed exception thrown when file is not found to more meaningful std::invalid_argument

### DIFF
--- a/examples/parse.cpp
+++ b/examples/parse.cpp
@@ -21,6 +21,11 @@ int main(int argc, char** argv)
         std::cerr << "Failed to parse " << argv[1] << ": " << e.what() << std::endl;
         return 1;
     }
+	catch (const std::invalid_argument& e)
+	{
+		std::cerr << "Failed to parse " << argv[1] << ": " << e.what() << std::endl;
+		return 1;
+	}
 
     return 0;
 }

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -3204,7 +3204,7 @@ class parser
 
 /**
  * Utility function to parse a file as a TOML file. Returns the root table.
- * Throws a parse_exception if the file cannot be opened.
+ * Throws a std::invalid_argument if the file cannot be opened.
  */
 inline std::shared_ptr<table> parse_file(const std::string& filename)
 {
@@ -3216,7 +3216,7 @@ inline std::shared_ptr<table> parse_file(const std::string& filename)
     std::ifstream file{filename};
 #endif
     if (!file.is_open())
-        throw parse_exception{filename + " could not be opened for parsing"};
+        throw std::invalid_argument{filename + " could not be opened for parsing"};
     parser p{file};
     return p.parse();
 }


### PR DESCRIPTION
I'm using cpptoml to parse config files for my application.
I do want to handle a file which could not be opened specially.
A file, which could not be opened, is imho not really a parsing error, because the parsing hasn't really started at this point.