### PR TITLE
Make header guard use a non-reserved identifier.

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -4,8 +4,8 @@
  * @date May 2013
  */
 
-#ifndef _CPPTOML_H_
-#define _CPPTOML_H_
+#ifndef CPPTOML_H
+#define CPPTOML_H
 
 #include <algorithm>
 #include <cassert>
@@ -3655,4 +3655,4 @@ inline std::ostream& operator<<(std::ostream& stream, const array& a)
     return stream;
 }
 } // namespace cpptoml
-#endif
+#endif // CPPTOML_H


### PR DESCRIPTION
C++ reserves names beginning with an underscore followed by a
capital letter for the implementation.