### PR TITLE
Fix find_end_of_date to actually find the end of date (was eating all…

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -2874,8 +2874,13 @@ class parser
     std::string::iterator find_end_of_date(std::string::iterator it,
                                            std::string::iterator end)
     {
-        return std::find_if(it, end, [](char c) {
-            return !is_number(c) && c != 'T' && c != ' ' && c != 'Z' && c != ':'
+        auto end_of_date = std::find_if(it, end, [](char c) {
+            return !is_number(c) && c != '-';
+        });
+        if (*end_of_date == ' ' && is_number(end_of_date[1])) 
+            end_of_date++;
+        return std::find_if(end_of_date, end, [](char c) {
+            return !is_number(c) && c != 'T' && c != 'Z' && c != ':'
                    && c != '-' && c != '+' && c != '.';
         });
     }

--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -3102,8 +3102,10 @@ class parser
                 throw_parse_exception("Unterminated inline table");
 
             consume_whitespace(it, end);
-            parse_key_value(it, end, tbl.get());
-            consume_whitespace(it, end);
+            if (*it != '}') {
+                parse_key_value(it, end, tbl.get());
+                consume_whitespace(it, end);
+            }
         } while (*it == ',');
 
         if (it == end || *it != '}')


### PR DESCRIPTION
… the whitespace behind a date to comment and failing)

E.g.
date = 1990-01-01 # some comment
da = 1200-01-01T00:00:00Z # some ohther comment (plain whitespace suffices to fail too)