### PR TITLE
Add a plain value method for retrieving value from option class

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -84,6 +84,11 @@ class option
         return &value_;
     }
 
+    const T& value() const
+    {
+        return value_;
+    }
+
     template <class U>
     T value_or(U&& alternative) const
     {


### PR DESCRIPTION
This provides a simple method to retrieve the value. It does not check if the value exists, as with the operator version.

```c++
uint32_t port = config->get_as<uint32_t>("port");

if (port) {
    exampleFunction(port.value());
} else {
    // Handle error
}
```

I understand this might not be a change you are interested in merging, but I just wanted to make a PR since it something that I personally would like to see in cpptoml.

If you are interested in merging this, I can update this PR with documentation.