### PR TITLE
cpptoml: Fix parsing of [int, double...] arrays

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -3025,7 +3025,6 @@ class parser
             case parse_type::OFFSET_DATETIME:
                 return parse_value_array<offset_datetime>(it, end);
             case parse_type::INT:
-                return parse_value_array<int64_t>(it, end);
             case parse_type::FLOAT:
                 return parse_value_array<double>(it, end);
             case parse_type::BOOL:


### PR DESCRIPTION
If the first value of an array is an integer, cpptoml assumes the rest are.
This pr makes the behavior of `parse_array` the same as `parse_value` (int falls through to double on the first element).
https://github.com/skystrife/cpptoml/blob/fededad7169e538ca47e11a9ee9251bc361a9a65/include/cpptoml.h#L2299
