### PR TITLE
Check BOM file Enconding

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -1901,6 +1901,9 @@ class parser
             auto it = line_.begin();
             auto end = line_.end();
             consume_whitespace(it, end);
+            if (line_number_ == 1){
+                check_BOM_encode(it, end);
+            }
             if (it == end || *it == '#')
                 continue;
             if (*it == '[')
@@ -3158,6 +3161,13 @@ class parser
                                   + "'---did you forget a '#'?");
     }
 
+    void check_BOM_encode(std::string::iterator& it,
+                            const std::string::iterator& end)
+    {
+        while (it != end && (*it == char(239) || *it == char(187) || *it == char(191) ))
+            ++it;
+    }
+    
     bool is_time(const std::string::iterator& it,
                  const std::string::iterator& end)
     {


### PR DESCRIPTION
Hi guys! Don't know if you are interested in this fix, but I'm using your cpptoml parser, and I have to face the fact that some files are encoded with BOM, and the parser doesn't retrieve them well. 

A BOM-encoded file, starts with the three following bytes, EF BB BF, corresponding to ï»¿. 

I add just some lines to remove them in the first line of the file.