### PR TITLE
behaviour of get_array_of<T>.value_or(5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ for (const auto& val : *vals)
 the key does not exist, is not of the array type, or contains values that
 are not of type `T`.
 
+If the key does not exist and the method is called with `value_or` function on the returned empty `option`, the containing vector type is zero intialised to the length supplied to `value_or`.
+
+
 For nested arrays, it looks like the following:
 
 ```cpp


### PR DESCRIPTION
i was surprise of the behaviour when calling value_or(x) on the option returned by get array of method.
added to the explaination that a 0 vector of lengh supplied to value or is initialised