### PR TITLE
Added string parse functionality

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -3231,6 +3231,21 @@ inline std::shared_ptr<table> parse_file(const std::string& filename)
     return p.parse();
 }
 
+
+/**
+ * Utility function to parse a file as a TOML file. Returns the root table.
+ * Throws a parse_exception if the file cannot be opened.
+ */
+inline std::shared_ptr<table> parse_string(const std::string& toml)
+    {
+
+        std::stringstream data{toml};
+        parser p{data};
+        return p.parse();
+    }
+
+
+
 template <class... Ts>
 struct value_accept;
 


### PR DESCRIPTION
This commit adds functionality to directly parse a string using cpptoml.
I found it quite hard to use current API as it requires a filename string

In many cases, where resource bundling is done, you do not have the possibility to access the file system, and in this case, the cpptoml library, in its current state completely fails to load.

This improves an already excellent library for toml parsing significantly for many cases.