### PR TITLE
g++-11 requires limits header

### DIFF
--- a/include/cpptoml.h
+++ b/include/cpptoml.h
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
The CRAN maintainers, who tend to be very proactive with new compiler builds, alerted me that my [RcppROML](https://github.com/eddelbuettel/rcpptoml) package was failing builds under `g++-11`, and hinted that the change was a one-liner.

I have now confirmed this (in an Ubuntu 21.04 container with `g++-11` from [this launchpad repo](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/volatile?field.series_filter=hirsute).  I will try to bundle this up in a new container too later in the week.