### PR TITLE
cmake: output cpptoml.pc for pkg-config discoverability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ target_include_directories(cpptoml INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cpptoml.pc.in"
+  "${PROJECT_SOURCE_DIR}/cpptoml.pc"
+  @ONLY)
+
 if (LIBDL_LIBRARY)
   target_link_libraries(cpptoml INTERFACE ${LIBDL_LIBRARY})
 endif()
@@ -87,6 +92,8 @@ install(FILES
           ${CMAKE_CURRENT_BINARY_DIR}/cpptoml/cpptomlConfig.cmake
         DESTINATION
           lib/cmake/cpptoml)
+install(FILES "${PROJECT_SOURCE_DIR}/cpptoml.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 export(EXPORT cpptoml-exports
        FILE ${CMAKE_CURRENT_BINARY_DIR}/cpptoml/cpptomlTargets.cmake)

--- a/cpptoml.pc.in
+++ b/cpptoml.pc.in
@@ -1,0 +1,7 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: cpptoml
+Description: A header-only library for parsing TOML
+Version: @cpptoml_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
I'm packaging `wireplumber` for NixOS (nixpkgs), and it uses this library. With this change, `meson` is able to just discover `cpptoml` via typical `pkg-config` mechanisms. I'm going to carry this patch for now.

Thanks!